### PR TITLE
Add meta referrer to header + fix broken link on 'About' page

### DIFF
--- a/layout/partials/header.html
+++ b/layout/partials/header.html
@@ -19,6 +19,7 @@ Parimal
   <meta name="keywords" content="{{ keywords }}, {{#if type}}{{ type }}{{/if}} {{ site.keywords }}" />
   <meta name="description" content="{{#if blurb}}{{ blurb }}{{else}}{{#if description}}{{ description }}{{else}}{{ site.description }}{{/if}}{{/if}}" />
   <meta name="author" content="{{ site.author }}">
+  <meta name="referrer" content="never" />
   {{#if img}}<meta property="og:image" content="http://parimalsatyal.github.io/{{ img }}" />{{/if}}
 	<link rel="stylesheet" href="/css/neustadt.css" type="text/css" media="all">
   <link href='https://fonts.googleapis.com/css?family=Playfair+Display:400,400italic,700,700italic' rel='stylesheet' type='text/css'>

--- a/src/about.md
+++ b/src/about.md
@@ -23,7 +23,7 @@ The *.fr* part is because I live in France. And because *.com* was not available
 
 Neustadt.fr is built using [Metalsmith](http://metalsmith.io), a node.js-based static site generator.
 
-This entire website is open-source (with an MIT license). There are public GitHub repositories for both [the Metalsmith back-end](https://github.com/parimalsatyal/neustadt.fr-metalsmith) and the [static front-end]((https://github.com/parimalsatyal/parimalsatyal.github.io) hosted on GitHub Pages. You are free to reuse the code in any way you please.
+This entire website is open-source (with an MIT license). There are public GitHub repositories for both [the Metalsmith back-end](https://github.com/parimalsatyal/neustadt.fr-metalsmith) and the [static front-end](https://github.com/parimalsatyal/parimalsatyal.github.io) hosted on GitHub Pages. You are free to reuse the code in any way you please.
 
 The fonts used on this website are also all free and shared with the SIL Open Font License. Thanks to [Jonathan Pinhorn](https://twitter.com/jonpinhorn_type) for [Karla](http://www.fontsquirrel.com/fonts/karla), [Claus Eggers Sørensen](http://www.forthehearts.net/about/) for [Playfair Display](http://www.forthehearts.net/typeface-design/playfair-display/) and [Eben Sorkin](https://github.com/EbenSorkin) for [Merriweather](https://github.com/EbenSorkin/Merriweather).
 


### PR DESCRIPTION
This tells browsers not to leak referrer information at all. See https://w3c.github.io/webappsec/specs/referrer-policy/#referrer-policy-delivery-meta

Note that while `no-referrer` is the preferred keyword, it wasn't supported by Microsoft Edge last time I checked. `never` (legacy) is, however, supported by Edge as well as recent FF/Chrome/Safari.
